### PR TITLE
:1234: Remove support for Lua 5.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lua_version: [ "5.4", "5.3", "5.2", "5.1", 'luajit-2.0', 'luajit-2.1' ]
+        lua_version: [ "5.3", "5.2", "5.1", 'luajit-2.0', 'luajit-2.1' ]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/flock-v1.0.0-1.rockspec
+++ b/flock-v1.0.0-1.rockspec
@@ -18,7 +18,7 @@ description = {
 }
 
 dependencies = {
-  'lua >= 5.1, <= 5.4',
+  'lua >= 5.1, <= 5.3',
   'torch_threads = v1.0.0',
   'torch_torch7 = v1.0.0',
   'gc_metatable = v1.0.0',


### PR DESCRIPTION
Problem:
- Torch paths module currently does not support Lua 5.4

Solution:
- Remove support for Lua 5.4 until the Torch paths can be updated.